### PR TITLE
Fix overwritten `baseDir` config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,7 @@ async function main() {
     .option('-r, --routes <routes>', 'Addtional routes to crawl contents from')
     .option('-d, -o, --out-dir <dir>', 'The directory to output files')
     .option('-q, --quiet', 'Output nothing in console')
-    .action(async (dir: string = '.', flags) => {
+    .action(async (dir: string | undefined, flags) => {
       const { Server } = await import('./Server')
       const { Crawler } = await import('./Crawler')
       const { Writer } = await import('./Writer')
@@ -59,14 +59,13 @@ async function main() {
       }
       config = Object.assign(
         {
+          baseDir: '.',
           outDir: '.presite',
           routes: ['/'],
         },
         configData,
         flags,
-        {
-          baseDir: dir,
-        }
+        dir && { baseDir: dir }
       )
 
       const logger = new Logger({ verbose: !flags.quiet })


### PR DESCRIPTION
Thank you for this amazing tool!

When running the `presite` command without any arguments, the current working directory is used as the source directory despite the `baseDir` config being set in `presite.config.js`.
This PR should fix it, while still allowing the source directory to be overridden through CLI.