### PR TITLE
feat: add linkFilter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ module.exports = {
 }
 ```
 
+### Filter out link to be crawled
+
+To prevent link (from `<a>` elements) to be crawled, you could use a linkFilter:
+
+```js
+module.exports = {
+  linkFilter(url) {
+    return !url.endsWith(".xml")
+  },
+}
+```
+
 ### Source directory
 
 This is the same as using CLI `presite ./path/to/your/spa`:

--- a/README.md
+++ b/README.md
@@ -180,12 +180,14 @@ module.exports = {
 
 ### Filter out link to be crawled
 
-To prevent link (from `<a>` elements) to be crawled, you could use a linkFilter:
+To prevent link (from `<a>` elements) to be crawled, you could use the `linkFilter` option:
 
 ```js
 module.exports = {
+  // Returns `true` to keep, `false` otherwise
   linkFilter(url) {
-    return !url.endsWith(".xml")
+    // Ignore URLs ending with .xml
+    return !url.endsWith('.xml')
   },
 }
 ```

--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -22,6 +22,7 @@ type CrawlerOptions = {
     routes: string[] | (() => Promise<string[]>)
     onBrowserPage?: (page: Page) => void | Promise<void>
     manually?: string | boolean
+    linkFilter?: (url: string) => boolean
   }
   writer: Writer
   logger: Logger
@@ -87,7 +88,11 @@ export class Crawler {
           })
 
           if (links && links.size > 0) {
-            for (const link of links) {
+            const filtered = options.linkFilter
+              ? Array.from(links).filter(options.linkFilter)
+              : links
+
+            for (const link of filtered) {
               queue.add(link)
             }
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ async function main() {
         routes?: string[] | (() => Promise<string[]>)
         onBrowserPage?: (page: Page) => void | Promise<void>
         manually?: boolean | string
+        linkFilter?: (url: string) => boolean
       }
 
       let config: Required<ConfigInput>
@@ -89,6 +90,7 @@ async function main() {
           routes: config.routes,
           onBrowserPage: config.onBrowserPage,
           manually: config.manually,
+          linkFilter: config.linkFilter
         },
         writer,
         logger,


### PR DESCRIPTION
This pr add an `linkFilter` option which can specified what links (from <a> elements) should get crawled.