### PR TITLE
fix: Pass on the `wait` option to taki

### DIFF
--- a/src/Crawler.ts
+++ b/src/Crawler.ts
@@ -15,13 +15,14 @@ const routeToFile = (route: string) => {
   return route.replace(/\/?$/, '/index.html')
 }
 
-type CrawlerOptions = {
+export type CrawlerOptions = {
   hostname: string
   port: number
   options: {
     routes: string[] | (() => Promise<string[]>)
     onBrowserPage?: (page: Page) => void | Promise<void>
     manually?: string | boolean
+    wait?: string | number
   }
   writer: Writer
   logger: Logger
@@ -84,6 +85,7 @@ export class Crawler {
                 )
               })
             },
+            wait: options.wait,
           })
 
           if (links && links.size > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,8 @@ import update from 'update-notifier'
 import JoyCon from 'joycon'
 import { Page } from 'puppeteer-core'
 
+import type { CrawlerOptions } from './Crawler'
+
 const pkg: typeof import('../package.json') = require('../package')
 
 update({ pkg }).notify()
@@ -33,12 +35,9 @@ async function main() {
       const { Writer } = await import('./Writer')
       const { Logger } = await import('./Logger')
 
-      type ConfigInput = {
+      type ConfigInput = CrawlerOptions['options'] & {
         baseDir?: string
         outDir?: string
-        routes?: string[] | (() => Promise<string[]>)
-        onBrowserPage?: (page: Page) => void | Promise<void>
-        manually?: boolean | string
       }
 
       let config: Required<ConfigInput>
@@ -89,6 +88,7 @@ async function main() {
           routes: config.routes,
           onBrowserPage: config.onBrowserPage,
           manually: config.manually,
+          wait: config.wait,
         },
         writer,
         logger,


### PR DESCRIPTION
To make it actually work, a patch is also needed on `taki` for [these 2 lines](https://github.com/egoist/taki/blob/master/src/index.ts#L81-L83) (the `typeof` operator is missing).
I was about to submit a PR there, before noticing that [a rewrite was in the making](https://github.com/egoist/taki/pull/3).
